### PR TITLE
Fix line_regexps wato variable name

### DIFF
--- a/share/check_mk/web/plugins/wato/access_logs.py
+++ b/share/check_mk/web/plugins/wato/access_logs.py
@@ -75,7 +75,7 @@ def _valuespec_agent_config_access_logs():
                         default_value = 300
                      )
                    ),
-                   ( "line_regexp",
+                   ( "line_regexps",
                      ListOfStrings(
                         title = _("Line Regexp Patterns"),
                         help = _("A list of custom regular expression which will be applied against each line of the access log file to extract the date and response status."


### PR DESCRIPTION
The variable which is used in the agent plugin is called line_regexps. The wato variable was line_regexp (missing s) - so the self configured regexes were never used.